### PR TITLE
oneplus2: Eliminate unnecessary KCAL related configs

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -97,16 +97,6 @@ on init
     # Scheduler
     chown system system /sys/module/cpu_boost/parameters/sysctl_thermal_aware_scheduling
 
-    # Display color calibration
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_enable
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_cont
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_hue
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_invert
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_min
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_sat
-    chown system system /sys/devices/platform/kcal_ctrl.0/kcal_val
-
     # Touchscreen
     chown root system /proc/touchpanel/double_swipe
     chmod 0660 /proc/touchpanel/double_swipe


### PR DESCRIPTION
We have no support for KCAL, so we do not have to make special tweaks
for them.

Remove these unused conigs from init scripts as a clean-up.

Change-Id: Iaf92956365fc3c541376a8960d0a5b10c01e86cd