### PR TITLE
oneplus2: Deprecate libjni_livedisplay

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -213,10 +213,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     lights.msm8994
 
-# LiveDisplay native
-PRODUCT_PACKAGES += \
-    libjni_livedisplay
-
 # Media
 PRODUCT_COPY_FILES += \
     $(LOCAL_PATH)/configs/media_codecs.xml:system/vendor/etc/media_codecs.xml \


### PR DESCRIPTION
This will be replaced by the new shiny HIDL HAL.

Change-Id: I4d8463640231799552ff259242cf42dc9f288a18