### PR TITLE
oneplus2: doze: use ExecutorService for listener registration

### DIFF
--- a/doze/src/org/lineageos/settings/doze/ProximitySensor.java
+++ b/doze/src/org/lineageos/settings/doze/ProximitySensor.java
@@ -24,6 +24,10 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.util.Log;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 public class ProximitySensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
@@ -38,6 +42,7 @@ public class ProximitySensor implements SensorEventListener {
     private SensorManager mSensorManager;
     private Sensor mSensor;
     private Context mContext;
+    private ExecutorService mExecutorService;
 
     private boolean mSawNear = false;
     private long mInPocketTime = 0;
@@ -46,6 +51,11 @@ public class ProximitySensor implements SensorEventListener {
         mContext = context;
         mSensorManager = mContext.getSystemService(SensorManager.class);
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY);
+        mExecutorService = Executors.newSingleThreadExecutor();
+    }
+
+    private Future<?> submit(Runnable runnable) {
+        return mExecutorService.submit(runnable);
     }
 
     @Override
@@ -81,11 +91,16 @@ public class ProximitySensor implements SensorEventListener {
 
     protected void enable() {
         if (DEBUG) Log.d(TAG, "Enabling");
-        mSensorManager.registerListener(this, mSensor, SensorManager.SENSOR_DELAY_NORMAL);
+        submit(() -> {
+            mSensorManager.registerListener(this, mSensor,
+                    SensorManager.SENSOR_DELAY_NORMAL);
+        });
     }
 
     protected void disable() {
         if (DEBUG) Log.d(TAG, "Disabling");
-        mSensorManager.unregisterListener(this, mSensor);
+        submit(() -> {
+            mSensorManager.unregisterListener(this, mSensor);
+        });
     }
 }

--- a/doze/src/org/lineageos/settings/doze/TiltSensor.java
+++ b/doze/src/org/lineageos/settings/doze/TiltSensor.java
@@ -25,6 +25,10 @@ import android.hardware.SensorManager;
 import android.os.SystemClock;
 import android.util.Log;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 public class TiltSensor implements SensorEventListener {
 
     private static final boolean DEBUG = false;
@@ -36,6 +40,7 @@ public class TiltSensor implements SensorEventListener {
     private SensorManager mSensorManager;
     private Sensor mSensor;
     private Context mContext;
+    private ExecutorService mExecutorService;
 
     private long mEntryTimestamp;
 
@@ -43,6 +48,11 @@ public class TiltSensor implements SensorEventListener {
         mContext = context;
         mSensorManager = mContext.getSystemService(SensorManager.class);
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_TILT_DETECTOR);
+        mExecutorService = Executors.newSingleThreadExecutor();
+    }
+
+    private Future<?> submit(Runnable runnable) {
+        return mExecutorService.submit(runnable);
     }
 
     @Override
@@ -68,13 +78,17 @@ public class TiltSensor implements SensorEventListener {
 
     protected void enable() {
         if (DEBUG) Log.d(TAG, "Enabling");
-        mSensorManager.registerListener(this, mSensor,
-                SensorManager.SENSOR_DELAY_NORMAL, BATCH_LATENCY_IN_MS * 1000);
-        mEntryTimestamp = SystemClock.elapsedRealtime();
+        submit(() -> {
+            mSensorManager.registerListener(this, mSensor,
+                    SensorManager.SENSOR_DELAY_NORMAL, BATCH_LATENCY_IN_MS * 1000);
+            mEntryTimestamp = SystemClock.elapsedRealtime();
+        });
     }
 
     protected void disable() {
         if (DEBUG) Log.d(TAG, "Disabling");
-        mSensorManager.unregisterListener(this, mSensor);
+        submit(() -> {
+            mSensorManager.unregisterListener(this, mSensor);
+        });
     }
 }


### PR DESCRIPTION
Replicate what Google did for SystemUI in this commit.
https://github.com/aosp-mirror/platform_frameworks_base/commit/fabc743bcf6e6623e530545c4b31285ea642f087

Registering a sensor seems to be an expensive operation,
and we do it on each screen-on event, so moving it to
an asynchronous task looks like a good idea anyway.

By moving all non-essential binder calls of the main thread or to the
next frame, we bring this down to 5ms, such that window animation
and Keyguard animation starts about at the same time.

The interesting part about the ExecutorService:
"Memory consistency effects: Actions in a thread prior to the submission
of a Runnable or Callable task to an ExecutorService happen-before any
actions taken by that task, which in turn happen-before the result is
retrieved via Future.get()."
(from https://developer.android.com/reference/java/util/concurrent/ExecutorService)

Change-Id: I4f37bb9a7dc9d7775d587d4ebd4b6619f3b77e81