### PR TITLE
oneplus2: Correct binary path in config.fs

### DIFF
--- a/config.fs
+++ b/config.fs
@@ -7,31 +7,31 @@ value:2951
 [AID_RFS_SHARED]
 value:2952
 
-[system/bin/wcnss_filter]
+[system/vendor/bin/wcnss_filter]
 mode: 0755
 user: AID_BLUETOOTH
 group: AID_BLUETOOTH
 caps: BLOCK_SUSPEND
 
-[system/bin/cnss-daemon]
+[system/vendor/bin/cnss-daemon]
 mode: 0755
 user: AID_SYSTEM
 group: AID_SYSTEM
 caps: NET_BIND_SERVICE
 
-[system/bin/pm-service]
+[system/vendor/bin/pm-service]
 mode: 0755
 user: AID_SYSTEM
 group: AID_SYSTEM
 caps: NET_BIND_SERVICE
 
-[system/bin/imsdatadaemon]
+[system/vendor/bin/imsdatadaemon]
 mode: 0755
 user: AID_SYSTEM
 group: AID_SYSTEM
 caps: NET_BIND_SERVICE
 
-[system/bin/ims_rtp_daemon]
+[system/vendor/bin/ims_rtp_daemon]
 mode: 0755
 user: AID_SYSTEM
 group: AID_RADIO


### PR DESCRIPTION
Change-Id: I320d118f964a21be531dbecfc8ee995e8e303a3d