### PR TITLE
oneplus2: Disable WiPower and A4WP support

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -26,12 +26,7 @@ ro.config.vc_call_vol_steps=7
 
 # Bluetooth
 bluetooth.enable_timeout_ms=12000
-bluetooth.hfp.client=1
-bt.max.hfpclient.connections=1
 vendor.qcom.bluetooth.soc=rome
-ro.bluetooth.a4wp=true
-ro.bluetooth.emb_wp_mode=true
-ro.bluetooth.wipower=true
 
 # Camera
 camera.disable_zsl_mode=1


### PR DESCRIPTION
 * Oneplus2 does not support wireless charging, also remove unused HFP
   properties.

Change-Id: I0d6ba41f387cf3f85ccd5166c70bdf6d2909d673