### PR TITLE
oneplus2: enable noatime mount option for CTS failure

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -13,7 +13,7 @@
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/userdata                /data             ext4    nosuid,nodev,noatime,noauto_da_alloc,commit=20                                                                  wait,check,encryptable=footer
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/cache                   /cache            f2fs    rw,discard,nosuid,nodev,noatime,inline_xattr,noinline_dentry                                                    wait
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/cache                   /cache            ext4    nosuid,nodev,noatime,noauto_da_alloc,commit=20                                                                  wait
-/dev/block/platform/soc.0/f9824900.sdhci/by-name/persist                 /persist          ext4    nosuid,nodev,barrier=1                                                                                          wait
+/dev/block/platform/soc.0/f9824900.sdhci/by-name/persist                 /persist          ext4    nosuid,nodev,noatime,barrier=1                                                                                  wait
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/misc                    /misc             emmc    defaults                                                                                                        defaults
 
 /dev/block/platform/soc.0/f9824900.sdhci/by-name/modem                   /firmware         vfat    ro,shortname=lower,uid=1000,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0                    wait


### PR DESCRIPTION
Enable noatime mount option for userdata, cache and
persist partitions.

Change-Id: Ie6fb063115ac6a1d62f9cf2814fd1c0b89e4d17f