### PR TITLE
oneplus2: Hax keystore

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -303,8 +303,8 @@ etc/firmware/a420_pfp.fw
 etc/firmware/a420_pm4.fw
 
 # Keystore - OxygenOS 3.6.0
-vendor/lib/hw/keystore.msm8994.so
-vendor/lib64/hw/keystore.msm8994.so
+vendor/lib64/hw/keystore.msm8994.so|567487839c061bc76f020ddb7b3e4abe5b2bd93b
+vendor/lib64/libcrypto_keystore.so|a09a8832939b5e15be00386293854af667e031db
 
 # Media - OxygenOS 3.6.0
 vendor/lib/libDivxDrm.so


### PR DESCRIPTION
* It came out that generating key pairs works when keystore hal is linked
  to libcrypto provided by original rom.
* As android.hardware.keymaster@3.0-service also uses libcrypto, do the
  following hax:
  - make keystore import libcrypto_keystore
  - change all imported symbols in hal from libcrypto to mangled names
  - mangle all exported symbols from libcrypto to mangled names

Following script did the job:

(Requires: https://github.com/lief-project/LIEF/)
------------------------------------------------------------------------------
import lief

mangle_symbol = lambda x: 'keystore_' + x
mangle_lib = lambda x: x.replace('.so', '_keystore.so')

keystore = lief.parse('keystore.msm8994.so.orig')
libcrypto = lief.parse('libcrypto.so.orig')

exported_symbol_names = [i.name for i in libcrypto.exported_symbols]

keystore_mangled_names = set()
libcrypto_mangled_names = set()
libcrypto_name = None
keystore_needed_mangled = False

for i in keystore.imported_symbols:
    if i.name in exported_symbol_names:
        i.name = mangle_symbol(i.name)
        keystore_mangled_names.add(i.name)

for i in libcrypto.exported_symbols:
    i.name = mangle_symbol(i.name)
    libcrypto_mangled_names.add(i.name)

for i in libcrypto.dynamic_entries:
    if i.tag == lief.ELF.DYNAMIC_TAGS.SONAME:
        libcrypto_name = i.name
        i.name = mangle_lib(i.name)

for i in keystore.dynamic_entries:
    if i.tag == lief.ELF.DYNAMIC_TAGS.NEEDED and i.name == libcrypto_name:
        i.name = mangle_lib(i.name)
        keystore_needed_mangled = True

assert keystore_mangled_names.issubset(libcrypto_mangled_names)
assert libcrypto_name is not None
assert keystore_needed_mangled is True

keystore.write('keystore.msm8994.so')
libcrypto.write(mangle_lib(libcrypto_name))
------------------------------------------------------------------------------

* Also remove 32bit keystore blob

Change-Id: Ied7e53c7a270bacef4f456210c36cfe9ccc4f22d