### PR TITLE
oneplus2: Restrict /dev/qseecom permissions

### DIFF
--- a/rootdir/etc/ueventd.qcom.rc
+++ b/rootdir/etc/ueventd.qcom.rc
@@ -106,8 +106,7 @@
 /dev/video*               0660   system     camera
 /dev/media*               0660   system     camera
 /dev/v4l-subdev*          0660   system     camera
-#changhua.li modify from 660 to 666 for alipay use tz
-/dev/qseecom              0666   system     drmrpc
+/dev/qseecom              0660   system     drmrpc
 /dev/qce                  0660   system     drmrpc
 /dev/seemplog             0660   system     system
 /dev/pft                  0660   system     drmrpc


### PR DESCRIPTION
 * This can only be used on stock, we have no tz / biometric
   support on custom roms for Alipay.

Change-Id: Ia0e878352ee5c1da4da1e62bb053d970a932f778