### PR TITLE
oneplus2: Disable SF backpressure

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -58,6 +58,7 @@ dalvik.vm.dex2oat-threads=2
 dalvik.vm.image-dex2oat-threads=4
 
 # Graphics
+debug.sf.disable_backpressure=1
 debug.sf.latch_unsignaled=1
 dev.pm.dyn_samplingrate=1
 persist.demo.hdmirotationlock=false


### PR DESCRIPTION
Change-Id: I4d5e9ec52901a8b7da9c0c439417a4ac90c512b3