### PR TITLE
oneplus2: Drop QC implemenation for audio sw effects

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -22,9 +22,6 @@ vendor/lib/libadiertac.so
 vendor/lib/libaudcal.so
 vendor/lib/libhwdaphal.so
 vendor/lib/hw/sound_trigger.primary.msm8994.so|37b21a3023f0a6c1d6dbc598bd1bb1eb6082e610
-vendor/lib/soundfx/libqcbassboost.so
-vendor/lib/soundfx/libqcreverb.so
-vendor/lib/soundfx/libqcvirt.so
 vendor/lib64/libacdb-fts.so
 vendor/lib64/libacdbloader.so|84eeda9e8ff8fdceebf40bb1e61cc076c0ac9a5b
 vendor/lib64/libacdbrtac.so


### PR DESCRIPTION
* AOSP implementation is used since 6f7fcb1d331c7b1fb17993068796e6da411e5f02

Change-Id: I4de7bfcac10c673087ca6be900ed8804c503e7a2